### PR TITLE
Erlaube alternative Titel für die "Sonstiges" Tabelle

### DIFF
--- a/style/rechnung.sty
+++ b/style/rechnung.sty
@@ -379,10 +379,10 @@
 }
 
 % Sonstigestabelle
-\NewEnviron{tabsonstiges}{%
+\NewEnviron{tabsonstiges}[1][]{%
   \def\temp{%
     \begin{tabularx}{\textwidth}{@{}>\platz X r@{}}
-    \textbf{\sonstigestext} & \multicolumn{1}{c}{\textbf{\betragtext}} \\
+    \textbf{\ifthenelse{\equal{#1}{}}{\sonstigestext}{#1}} & \multicolumn{1}{c}{\textbf{\betragtext}} \\
     \hline}%
     \expandafter\temp\BODY%
     \end{tabularx}%


### PR DESCRIPTION
Normal:
``` tex
\begin{tabsonstiges}
  \sonstiges{Verladung}{100}
  \sonstiges{Lieferung ab Werk}{250}
\end{tabsonstiges}
```
![Screenshot from 2021-11-04 17-50-12](https://user-images.githubusercontent.com/16748619/140383258-b95d99e0-8235-4b68-b0ab-d8308cb45e81.png)

Mit alternativem Titel:
``` tex
\begin{tabsonstiges}[Pauschale Leistungen]
  \sonstiges{Verladung}{100}
  \sonstiges{Lieferung ab Werk}{250}
\end{tabsonstiges}
```
![Screenshot from 2021-11-04 17-50-33](https://user-images.githubusercontent.com/16748619/140383284-e6dbb776-64e5-4d8b-8855-f6d6fbb82ffe.png)

